### PR TITLE
Fixed broken doc links in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,16 +5,16 @@ Sunbeam OpenStack libraries and documentation
 Tutorials
 ---------
 
-* `Deploying Sunbeam Charms <doc/deploy-sunbeam-charms>`_
-* `Writing an OpenStack API charm with Sunbeam <doc/writing-OS-API-charm>`_
+* `Deploying Sunbeam Charms <doc/deploy-sunbeam-charms.rst>`_
+* `Writing an OpenStack API charm with Sunbeam <doc/writing-OS-API-charm.rst>`_
 
 How-Tos
 -------
 
-* `How-To write a pebble handler <doc/howto-pebble-handler>`_
-* `How-To write a relation handler <doc/howto-relation-handler>`_
-* `How-To write a charm context <doc/howto-config-context>`_
-* `How-To expose services outside of K8S <doc/howto-expose-services>`_
+* `How-To write a pebble handler <doc/howto-pebble-handler.rst>`_
+* `How-To write a relation handler <doc/howto-relation-handler.rst>`_
+* `How-To write a charm context <doc/howto-config-context.rst>`_
+* `How-To expose services outside of K8S <doc/howto-expose-services.rst>`_
 
 Reference
 ---------
@@ -24,4 +24,4 @@ Reference
 Concepts
 --------
 
-`Sunbeam Concepts <doc/concepts>`_
+`Sunbeam Concepts <doc/concepts.rst>`_


### PR DESCRIPTION
Noticed that the links redirect to a page not found, added a fix.